### PR TITLE
Use relative font sizes

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -37,7 +37,7 @@
 
   set table.header(repeat: false)
 
-  show table.cell.where(y: 0): set text(weight: "bold", size: 1.10em)
+  show table.cell.where(y: 0): set text(weight: "bold", size: 1.09em)
 
   columns(column-number)[
     #align(center)[

--- a/lib.typ
+++ b/lib.typ
@@ -37,19 +37,19 @@
 
   set table.header(repeat: false)
 
-  show table.cell.where(y: 0): set text(weight: "bold", size: 12pt)
+  show table.cell.where(y: 0): set text(weight: "bold", size: 1.10em)
 
   columns(column-number)[
     #align(center)[
-      #box(height: 20pt)[
+      #box(height: 1.82em)[
         #if icon != none {
           set image(height: 100%)
           box(icon, baseline: 25%)
         }
-        #text(17pt, title)
+        #text(1.55em, title)
       ]
 
-      #text(10pt, subtitle)
+      #text(0.91em, subtitle)
     ]
 
     #doc


### PR DESCRIPTION
Currently the font values are all hard coded, making it awkward to use when using alternative paper sizes (which I believe is a common use case of cheat sheets, I'm making a 3"x5" index card), since the text set rule does not affect the font sizes rendered by cram-snap

This PR makes all the font sizes use `em`, so they are all proportional to the base font size set by the user.

Here's an example of a 3"x5" document before this change:
<img width="1730" alt="Screenshot 2024-10-23 at 10 57 34 AM" src="https://github.com/user-attachments/assets/7b5c70cd-2b07-4962-a183-53e158282ea3">

And after:
<img width="1730" alt="Screenshot 2024-10-23 at 10 57 18 AM" src="https://github.com/user-attachments/assets/beb12f6b-3764-4310-95d4-fa0994502db1">
