### PR TITLE
Adds fill-color and stroke-color choices and bumps version to 0.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ arguments:
 - `subtitle`: Subtitle of the document
 - `icon`: Image that appears next to the title
 - `column-number`: Number of columns
+- `fill-color` : rgb color of filled rows (defaults to `#F2F2F2`)
+- `stroke-color` rgb color of the stroke under each heading (defaults to `21222C`)
 
 The `theader` function is a wrapper around the `table.header` function that
 creates a header and takes `colspan` as argument to span the header across

--- a/lib.typ
+++ b/lib.typ
@@ -3,6 +3,8 @@
   icon: none,
   column-number: 2,
   subtitle: none,
+  fill-color: "F2F2F2",
+  stroke-color: "21222C",
   doc,
 ) = {
   let table_stroke(color) = (
@@ -31,8 +33,8 @@
   set table(
     align: left + horizon,
     columns: (2fr, 3fr),
-    fill: table_fill(rgb("F2F2F2")),
-    stroke: table_stroke(rgb("21222C")),
+    fill: table_fill(rgb(fill-color)),
+    stroke: table_stroke(rgb(stroke-color)),
   )
 
   set table.header(repeat: false)

--- a/typst.toml
+++ b/typst.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cram-snap"
-version = "0.2.1"
+version = "0.2.2"
 entrypoint = "lib.typ"
 repository = "https://github.com/kamack38/cram-snap"
 authors = ["kamack38"]


### PR DESCRIPTION
* Adds the ability to change fill-color (the color of filled rows) and stroke-color the color of the stroke under each heading.
* Updates the documentation accordingly
* bumps version to 0.2.2 as this is a backward compatible change (defaults colors are those that were in 0.2.1)